### PR TITLE
Add switch to read properties from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,24 @@ Please fill the values for the following keys alone.
 client_secret=  
 redirect_uri=  
 accounts_url=https://accounts.zoho.com  
-token_persistence_path=  
+token_persistence_path= 
+
+Alternatively, you can provide the values for configuration and OAuth by using environment variables:
+Setting `USE_ENV_FOR_ZOHO_CONFIG` to 'true' will enable the environment configuration. The variables are listed below and map to the configuration file keys above:
+
+* `ZOHO_API_BASE_URL`
+* `ZOHO_API_VERSION`
+* `ZOHO_SANDBOX`
+* `ZOHO_APPLICATION_LOG_FILE_PATH`
+* `ZOHO_CURRENT_USER_EMAIL`
+
+* `ZOHO_OAUTH_CLIENT_ID`
+* `ZOHO_OAUTH_SECRET`
+* `ZOHO_OAUTH_REDIRECT_URI`
+* `ZOHO_OAUTH_ACCOUNTS_URL`
+* `ZOHO_OAUTH_TOKEN_PERSISTENCE_PATH`
+* `ZOHO_OAUTH_ACCESS_TYPE`
+ 
 
 client_id, client_secret and redirect_uri are your OAuth client’s configurations that you get after registering your Zoho client.
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='zcrmsdk',
-    version='1.0.0',
+    version='1.0.1',
 
     description='Zoho CRM SDK for Python developers',
     long_description=long_description,

--- a/zcrmsdk/OAuthClient.py
+++ b/zcrmsdk/OAuthClient.py
@@ -10,28 +10,43 @@ class ZohoOAuth(object):
     '''
     This class is to load oauth configurations and provide OAuth request URIs
     '''
-    configProperties={}
-    #iamURL='https://accounts.zoho.com'
-    
+    configProperties = {}
+
     def __init__(self):
         '''
         Constructor
         '''
+
     @staticmethod
     def initialize():
         try:
             from Path import PathIdentifier
             import os
-            #dirSplit=os.path.split(PathIdentifier.get_client_library_root())
-            #resources_path = os.path.join(dirSplit[0],'resources','oauth_configuration.properties')
-            resources_path = os.path.join(PathIdentifier.get_client_library_root(),'resources','oauth_configuration.properties')
-            filePointer=open(resources_path,"r")
-            ZohoOAuth.configProperties=ZohoOAuth.get_file_content_as_dictionary(filePointer)
-            oAuthParams=ZohoOAuthParams.get_instance(ZohoOAuth.configProperties[ZohoOAuthConstants.CLIENT_ID], ZohoOAuth.configProperties[ZohoOAuthConstants.CLIENT_SECRET], ZohoOAuth.configProperties[ZohoOAuthConstants.REDIRECT_URL])
+
+            if os.environ.get('USE_ENV_FOR_ZOHO_CONFIG') == 'true':
+                zoho_oauth_config = dict(
+                    client_id=os.environ.get('ZOHO_OAUTH_CLIENT_ID'),
+                    client_secret=os.environ.get('ZOHO_OAUTH_SECRET'),
+                    redirect_uri=os.environ.get('ZOHO_OAUTH_REDIRECT_URI'),
+                    accounts_url=os.environ.get('ZOHO_OAUTH_ACCOUNTS_URL'),
+                    token_persistence_path=os.environ.get('ZOHO_OAUTH_TOKEN_PERSISTENCE_PATH'),
+                    access_type=os.environ.get('ZOHO_OAUTH_ACCESS_TYPE')
+                )
+            else:
+                resources_path = os.path.join(PathIdentifier.get_client_library_root(), 'resources',
+                                              'oauth_configuration.properties')
+                file_pointer = open(resources_path, "r")
+                zoho_oauth_config = ZohoOAuth.get_file_content_as_dictionary(file_pointer)
+
+            ZohoOAuth.configProperties = zoho_oauth_config
+            oAuthParams = ZohoOAuthParams.get_instance(ZohoOAuth.configProperties[ZohoOAuthConstants.CLIENT_ID],
+                                                       ZohoOAuth.configProperties[ZohoOAuthConstants.CLIENT_SECRET],
+                                                       ZohoOAuth.configProperties[ZohoOAuthConstants.REDIRECT_URL])
             ZohoOAuthClient.get_instance(oAuthParams)
         except Exception as ex:
-            OAuthLogger.add_log('Exception occured while reading oauth configurations',logging.ERROR,ex)
+            OAuthLogger.add_log('Exception occured while reading oauth configurations', logging.ERROR, ex)
             raise ex
+
     @staticmethod
     def get_file_content_as_dictionary(filePointer) :
         dictionary={}

--- a/zcrmsdk/Utility.py
+++ b/zcrmsdk/Utility.py
@@ -15,7 +15,7 @@ class HTTPConnector(object):
     @staticmethod
     def get_instance(url,params,headers,body,method,apiKey,is_bulk_req):
         return HTTPConnector(url,params,headers,body,method,apiKey,is_bulk_req)
-    
+
     def __init__(self, url,params,headers,body,method,apiKey,is_bulk_req):
         '''
         Constructor
@@ -28,7 +28,7 @@ class HTTPConnector(object):
         self.api_key=apiKey
         self.is_bulk_req=is_bulk_req
         self.file=None
-        
+
     def trigger_request(self):
         response=None
         if(self.req_method == APIConstants.REQUEST_METHOD_GET):
@@ -82,20 +82,20 @@ class APIConstants(object):
     REQUEST_METHOD_POST="POST"
     REQUEST_METHOD_PUT="PUT"
     REQUEST_METHOD_DELETE="DELETE"
-    
+
     OAUTH_HEADER_PREFIX="Zoho-oauthtoken "
     AUTHORIZATION="Authorization"
-    
+
     API_NAME="api_name"
     INVALID_ID_MSG = "The given id seems to be invalid."
     API_MAX_RECORDS_MSG = "Cannot process more than 100 records at a time."
     INVALID_DATA="INVALID_DATA"
-    
+
     CODE_SUCCESS = "SUCCESS"
-    
+
     STATUS_SUCCESS = "success"
     STATUS_ERROR = "error"
-    
+
     LEADS = "Leads"
     ACCOUNTS = "Accounts"
     CONTACTS = "Contacts"
@@ -104,17 +104,17 @@ class APIConstants(object):
     SALESORDERS = "SalesOrders"
     INVOICES = "Invoices"
     PURCHASEORDERS = "PurchaseOrders"
-    
+
     PER_PAGE = "per_page"
     PAGE = "page"
     COUNT = "count"
     MORE_RECORDS = "more_records"
-    
+
     MESSAGE = "message"
     CODE = "code"
     STATUS = "status"
     DETAILS="details"
-    
+
     DATA = "data"
     INFO = "info"
     FIELDS='fields'
@@ -126,7 +126,7 @@ class APIConstants(object):
     ROLES='roles'
     PROFILES='profiles'
     USERS='users'
-    
+
     RESPONSECODE_OK=200
     RESPONSECODE_CREATED=201
     RESPONSECODE_ACCEPTED=202
@@ -144,40 +144,58 @@ class APIConstants(object):
     RESPONSECODE_TOO_MANY_REQUEST=429
     RESPONSECODE_INTERNAL_SERVER_ERROR=500
     RESPONSECODE_INVALID_INPUT=0
-    
+
     DOWNLOAD_FILE_PATH="../../../../../../resources"
-    
+
     USER_EMAIL_ID="user_email_id"
     ACTION="action"
     DUPLICATE_FIELD="duplicate_field"
     NO_CONTENT="No Content"
     FAULTY_RESPONSE_CODES=[RESPONSECODE_NO_CONTENT,RESPONSECODE_NOT_FOUND,RESPONSECODE_AUTHORIZATION_ERROR,RESPONSECODE_BAD_REQUEST,RESPONSECODE_FORBIDDEN,RESPONSECODE_INTERNAL_SERVER_ERROR,RESPONSECODE_METHOD_NOT_ALLOWED,RESPONSECODE_MOVED_PERMANENTLY,RESPONSECODE_MOVED_TEMPORARILY,RESPONSECODE_REQUEST_ENTITY_TOO_LARGE,RESPONSECODE_TOO_MANY_REQUEST,RESPONSECODE_UNSUPPORTED_MEDIA_TYPE]
     ATTACHMENT_URL="attachmentUrl"
-    
+
     ACCESS_TOKEN_EXPIRY="X-ACCESSTOKEN-RESET";
     CURR_WINDOW_API_LIMIT="X-RATELIMIT-LIMIT";
     CURR_WINDOW_REMAINING_API_COUNT="X-RATELIMIT-REMAINING";
     CURR_WINDOW_RESET="X-RATELIMIT-RESET";
     API_COUNT_REMAINING_FOR_THE_DAY="X-RATELIMIT-DAY-REMAINING";
     API_LIMIT_FOR_THE_DAY="X-RATELIMIT-DAY-LIMIT"
-    
+
+
 class ZCRMConfigUtil(object):
     '''
     This class is to deal with configuration related things
     '''
-    config_prop_dict={}
+    config_prop_dict = {}
+
     @staticmethod
     def get_instance():
         return ZCRMConfigUtil()
+
     @staticmethod
-    def initialize(isToInitializeOAuth):
+    def initialize(is_to_initialize_oauth):
         import os
-        from Path import PathIdentifier
-        resources_path = os.path.join(PathIdentifier.get_client_library_root(),'resources','configuration.properties')
-        filePointer=open(resources_path,"r")
-        ZCRMConfigUtil.config_prop_dict=CommonUtil.get_file_content_as_dictionary(filePointer)
-        if(isToInitializeOAuth):
+
+        if os.environ.get('USE_ENV_FOR_ZOHO_CONFIG') == 'true':
+            zoho_config = dict(
+                apiBaseUrl=os.environ.get('ZOHO_API_BASE_URL'),
+                apiVersion=os.environ.get('ZOHO_API_VERSION'),
+                sandbox=os.environ.get('ZOHO_SANDBOX'),
+                applicationLogFilePath=os.environ.get('ZOHO_APPLICATION_LOG_FILE_PATH'),
+                currentUserEmail=os.environ.get('ZOHO_CURRENT_USER_EMAIL')
+            )
+        else:
+            from Path import PathIdentifier
+            resources_path = os.path.join(PathIdentifier.get_client_library_root(), 'resources',
+                                          'configuration.properties')
+            file_pointer = open(resources_path, "r")
+            zoho_config = CommonUtil.get_file_content_as_dictionary(file_pointer)
+
+        ZCRMConfigUtil.config_prop_dict = zoho_config
+
+        if is_to_initialize_oauth:
             ZohoOAuth.initialize()
+
     @staticmethod
     def get_api_base_url():
         return ZCRMConfigUtil.config_prop_dict["apiBaseUrl"]
@@ -193,7 +211,7 @@ class ZCRMConfigUtil(object):
             userEmail=ZCRMConfigUtil.config_prop_dict['currentUserEmail']
         clientIns=ZohoOAuth.get_client_instance()
         return clientIns.get_access_token(userEmail)
-        
+
 class CommonUtil(object):
     '''
     This class is to provide utility methods
@@ -208,7 +226,7 @@ class CommonUtil(object):
                 dictionary[keyValue[0].strip()]=keyValue[1].strip()
         filePointer.close()
         return dictionary
-    
+
     @staticmethod
     def raise_exception(url,message,details,content=None):
         zcrm_exception=ZCRMException(url,APIConstants.RESPONSECODE_INVALID_INPUT,message,APIConstants.STATUS_ERROR,details,content)
@@ -216,7 +234,7 @@ class CommonUtil(object):
         from CLException import Logger
         Logger.add_log(message,logging.ERROR,zcrm_exception)
         raise zcrm_exception
-    
+
     @staticmethod
     def create_api_supported_input_json(input_json,api_key):
         if input_json is None:


### PR DESCRIPTION
This change enables reading of configuration and oauth settings from environment variables instead of directly modifying the .properties files inside the site-packages directory. Workaround/solution for #2.