### PR TITLE
Add mysql-connector-python dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     install_requires=[
         'requests',
+        'mysql-connector-python'
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='zcrmsdk',
-    version='1.0.0',
+    version='1.0.2',
 
     description='Zoho CRM SDK for Python developers',
     long_description=long_description,


### PR DESCRIPTION
Add mysql-connector-python dependency so it is not necessary to install separately.